### PR TITLE
cpp: add transaction costs and slippage to backtest

### DIFF
--- a/cpp/engine/include/qe/backtest.hpp
+++ b/cpp/engine/include/qe/backtest.hpp
@@ -1,23 +1,37 @@
 #pragma once
 
+#include <cstddef>
 #include <vector>
+
 #include "qe/data.hpp"
 
 namespace qe {
 
+struct BacktestCosts {
+  // basis points (bps). 1 bp = 0.01%.
+  // cost per trade = fee_bps + slippage_bps.
+  double fee_bps = 0.0;
+  double slippage_bps = 0.0;
+};
+
 struct BacktestResult {
-  std::vector<double> equity;     // length = returns len (or prices length-1)
-  std::vector<double> strat_ret;  // strategy returns per step
+  std::vector<double> equity;     // equity curve 
+  std::vector<double> strat_ret;  // strategy returns per step (includes cost impact)
+
   double total_return = 0.0;
   double max_drawdown = 0.0;
   double sharpe = 0.0;
+
+  std::size_t n_trades = 0;
+  double total_cost = 0.0; // total cost in equity units
 };
 
 BacktestResult backtest_sma_crossover(
   const OhlcvTable& data,
   std::size_t fast_window,
   std::size_t slow_window,
-  double initial_equity = 1.0
+  double initial_equity = 1.0,
+  BacktestCosts costs = {}
 );
 
-} // qe
+} //qe

--- a/cpp/engine/src/backtest.cpp
+++ b/cpp/engine/src/backtest.cpp
@@ -1,12 +1,11 @@
 #include "qe/backtest.hpp"
 
-#include <algorithm>
+#include "qe/indicators.hpp"
+
 #include <cmath>
 #include <limits>
+#include <numeric>
 #include <stdexcept>
-#include <string>
-
-#include "qe/indicators.hpp"
 
 namespace qe {
 
@@ -14,47 +13,51 @@ static bool is_nan(double x) {
   return std::isnan(x);
 }
 
+// compute max drawdown from equity curve
 static double compute_max_drawdown(const std::vector<double>& equity) {
-  if (equity.empty()) return 0.0;
-
-  double peak = equity[0];
+  double peak = equity.front();
   double max_dd = 0.0;
 
   for (double v : equity) {
-    peak = std::max(peak, v);
-    if (peak > 0.0) {
-      double dd = (peak - v) / peak;
-      max_dd = std::max(max_dd, dd);
+    if (v > peak) {
+      peak = v;
+    }
+    double dd = (peak - v) / peak;
+    if (dd > max_dd) {
+      max_dd = dd;
     }
   }
+
   return max_dd;
 }
 
-static double compute_sharpe(const std::vector<double>& r) {
-  // Sharpe on per-period returns (no annualization yet)
-  if (r.empty()) return 0.0;
+// simple Sharpe (no annualization)
+static double compute_sharpe(const std::vector<double>& returns) {
+  if (returns.empty()) {
+    return 0.0;
+  }
 
-  double mean = 0.0;
-  for (double x : r) mean += x;
-  mean /= static_cast<double>(r.size());
+  double mean =
+    std::accumulate(returns.begin(), returns.end(), 0.0) /
+    static_cast<double>(returns.size());
 
   double var = 0.0;
-  for (double x : r) {
-    double d = x - mean;
+  for (double r : returns) {
+    double d = r - mean;
     var += d * d;
   }
-  var /= static_cast<double>(r.size());
+  var /= static_cast<double>(returns.size());
 
-  double sd = std::sqrt(var);
-  if (sd == 0.0) return 0.0;
-  return mean / sd;
+  double stddev = std::sqrt(var);
+  return (stddev > 0.0) ? (mean / stddev) : 0.0;
 }
 
 BacktestResult backtest_sma_crossover(
   const OhlcvTable& data,
   std::size_t fast_window,
   std::size_t slow_window,
-  double initial_equity
+  double initial_equity,
+  BacktestCosts costs
 ) {
   if (fast_window == 0 || slow_window == 0) {
     throw std::invalid_argument("windows must be > 0");
@@ -62,56 +65,69 @@ BacktestResult backtest_sma_crossover(
   if (fast_window >= slow_window) {
     throw std::invalid_argument("fast_window must be < slow_window");
   }
-  const std::size_t min_rows = slow_window + 1;
-  if (data.size() < min_rows) {
-    throw std::invalid_argument(
-      "not enough data: need at least " + std::to_string(min_rows) +
-      " rows for slow_window=" + std::to_string(slow_window) +
-      " (got " + std::to_string(data.size()) + ")"
-    );
-  }
-
   if (initial_equity <= 0.0) {
     throw std::invalid_argument("initial_equity must be > 0");
   }
+  if (data.size() <= slow_window) {
+    throw std::invalid_argument("not enough data for slow_window");
+  }
 
-  // close-to-close returns (length n-1)
-  std::vector<double> r = compute_returns(data);
+  // compute returns
+  std::vector<double> ret = compute_returns(data);
 
-  // close vector aligned to returns indices
-  // returns[i] corresponds to close[i] -> close[i+1]
-  std::vector<double> close;
-  close.reserve(data.size());
-  for (const auto& row : data) close.push_back(row.close);
-
-  // Compute SMAs on returns index space by using close[1..] (aligned to r indices)
-  std::vector<double> close_aligned(close.begin() + 1, close.end()); // length N-1
-  std::vector<double> fast = rolling_mean(close_aligned, fast_window);
-  std::vector<double> slow = rolling_mean(close_aligned, slow_window);
+  // rolling indicators on returns
+  std::vector<double> fast = rolling_mean(ret, fast_window);
+  std::vector<double> slow = rolling_mean(ret, slow_window);
 
   BacktestResult out;
-  out.strat_ret.assign(r.size(), 0.0);
-  out.equity.assign(r.size(), initial_equity);
+  out.equity.resize(ret.size());
+  out.strat_ret.resize(ret.size());
 
   double eq = initial_equity;
   int pos = 0; // 0 = flat, 1 = long
 
-  for (std::size_t i = 0; i < r.size(); ++i) {
-    // Only trade when both SMAs are defined, throw error if not (?)
+  const double cost_frac =
+    (costs.fee_bps + costs.slippage_bps) / 10000.0;
+
+  // main backtest loop 
+  for (std::size_t i = 0; i < ret.size(); ++i) {
+    int new_pos = pos;
+    bool traded = false;
+
     if (!is_nan(fast[i]) && !is_nan(slow[i])) {
-      pos = (fast[i] > slow[i]) ? 1 : 0;
+      new_pos = (fast[i] > slow[i]) ? 1 : 0;
     }
 
-    double sr = static_cast<double>(pos) * r[i];
+    // apply transaction costs on position change
+    if (new_pos != pos) {
+      traded = true;
+
+      double cost_amount = eq * cost_frac;
+      eq -= cost_amount;
+
+      out.n_trades += 1;
+      out.total_cost += cost_amount;
+
+      pos = new_pos;
+    }
+
+    // Strategy return INCLUDING cost impact
+    double sr = static_cast<double>(pos) * ret[i];
+    if (traded) {
+      sr -= cost_frac; // apprx cost impact on returns
+    }
+
     out.strat_ret[i] = sr;
 
     eq *= (1.0 + sr);
     out.equity[i] = eq;
   }
 
+  // metrics
   out.total_return = (out.equity.back() / initial_equity) - 1.0;
   out.max_drawdown = compute_max_drawdown(out.equity);
   out.sharpe = compute_sharpe(out.strat_ret);
+
   return out;
 }
 

--- a/cpp/engine/src/main.cpp
+++ b/cpp/engine/src/main.cpp
@@ -40,8 +40,7 @@ int main(int argc, char** argv) {
 
       try {
         qe::OhlcvTable table = qe::read_ohlcv_csv(data_path);
-        std::cout << "Loaded " << table.size()
-                  << " rows from " << data_path << "\n";
+        std::cout << "Loaded " << table.size() << " rows from " << data_path << "\n";
       } catch (const std::exception& ex) {
         std::cerr << "Error: " << ex.what() << "\n";
         return 1;
@@ -50,7 +49,7 @@ int main(int argc, char** argv) {
       return 0;
     }
 
- 
+
     // Indicators (I4)
 
     if (cmd == "indicators") {
@@ -100,15 +99,19 @@ int main(int argc, char** argv) {
       return 0;
     }
 
- 
-    // Backtest (I5)
-  
+    // Backtest (I5/6/7)
+
     if (cmd == "backtest") {
       std::string data_path;
       std::string out_dir;
+
       std::size_t fast = 5;
       std::size_t slow = 20;
       double initial = 1.0;
+
+      // I7: costs/slippage
+      double fee_bps = 0.0;
+      double slip_bps = 0.0;
 
       for (int i = 2; i < argc; ++i) {
         std::string arg = argv[i];
@@ -122,6 +125,10 @@ int main(int argc, char** argv) {
           initial = std::stod(argv[++i]);
         } else if (arg == "--out" && i + 1 < argc) {
           out_dir = argv[++i];
+        } else if (arg == "--fee-bps" && i + 1 < argc) {
+          fee_bps = std::stod(argv[++i]);
+        } else if (arg == "--slip-bps" && i + 1 < argc) {
+          slip_bps = std::stod(argv[++i]);
         }
       }
 
@@ -132,21 +139,32 @@ int main(int argc, char** argv) {
 
       try {
         qe::OhlcvTable table = qe::read_ohlcv_csv(data_path);
-        qe::BacktestResult r = qe::backtest_sma_crossover(table, fast, slow, initial);
+
+        qe::BacktestCosts costs;
+        costs.fee_bps = fee_bps;
+        costs.slippage_bps = slip_bps;
+
+        qe::BacktestResult r = qe::backtest_sma_crossover(table, fast, slow, initial, costs);
 
         std::cout << "backtest: sma_crossover fast=" << fast
                   << " slow=" << slow
-                  << " initial=" << initial << "\n";
+                  << " initial=" << initial
+                  << " fee_bps=" << fee_bps
+                  << " slip_bps=" << slip_bps << "\n";
 
         std::cout << "total_return=" << r.total_return
                   << " sharpe=" << r.sharpe
                   << " max_drawdown=" << r.max_drawdown
                   << " win_rate=" << qe::compute_win_rate(r.strat_ret) << "\n";
 
+        std::cout << "trades=" << r.n_trades
+                  << " total_cost=" << r.total_cost << "\n";
+
         if (!r.equity.empty()) {
           std::cout << "final_equity=" << r.equity.back() << "\n";
         }
 
+        // Issue 6: write outputs
         if (!out_dir.empty()) {
           std::filesystem::create_directories(out_dir);
 
@@ -171,15 +189,16 @@ int main(int argc, char** argv) {
     }
   }
 
-  
-  // Usage
 
+  // Usage
+ 
   std::cout << "qe_cli\n";
   std::cout << "Usage:\n";
   std::cout << "  qe_cli --version\n";
   std::cout << "  qe_cli run --data <csv_path>\n";
   std::cout << "  qe_cli indicators --data <csv_path> [--window N]\n";
-  std::cout << "  qe_cli backtest --data <csv_path> [--fast N] [--slow N] [--initial X] [--out <dir>]\n";
+  std::cout << "  qe_cli backtest --data <csv_path> [--fast N] [--slow N] [--initial X] "
+               "[--out <dir>] [--fee-bps B] [--slip-bps B]\n";
 
   return 0;
 }

--- a/cpp/engine/src/report.cpp
+++ b/cpp/engine/src/report.cpp
@@ -1,9 +1,10 @@
 #include "qe/report.hpp"
 
+#include <cmath>
 #include <fstream>
 #include <iomanip>
 #include <stdexcept>
-#include <cmath>
+
 namespace qe {
 
 double compute_win_rate(const std::vector<double>& strat_returns) {
@@ -15,7 +16,6 @@ double compute_win_rate(const std::vector<double>& strat_returns) {
   std::size_t total = 0;
 
   for (double r : strat_returns) {
-    // Ignore NaNs if ever appear
     if (std::isnan(r)) {
       continue;
     }
@@ -28,6 +28,7 @@ double compute_win_rate(const std::vector<double>& strat_returns) {
   if (total == 0) {
     return 0.0;
   }
+
   return static_cast<double>(wins) / static_cast<double>(total);
 }
 
@@ -90,6 +91,8 @@ void write_report_json(
   out << "    \"total_return\": " << result.total_return << ",\n";
   out << "    \"sharpe\": " << result.sharpe << ",\n";
   out << "    \"max_drawdown\": " << result.max_drawdown << ",\n";
+  out << "    \"n_trades\": " << result.n_trades << ",\n";
+  out << "    \"total_cost\": " << result.total_cost << ",\n";
   out << "    \"win_rate\": " << win_rate << "\n";
   out << "  },\n";
   out << "  \"series\": {\n";
@@ -98,4 +101,4 @@ void write_report_json(
   out << "}\n";
 }
 
-} // qe
+} // namespace qe


### PR DESCRIPTION
updated backtest to have transaction costs and slippage, changed report values